### PR TITLE
insert semicolon in Lclass;method for mixin target

### DIFF
--- a/src/main/kotlin/com/kotlindiscord/kordex/ext/mappings/utils/Mappings.kt
+++ b/src/main/kotlin/com/kotlindiscord/kordex/ext/mappings/utils/Mappings.kt
@@ -326,7 +326,7 @@ fun methodsToPages(
                 text += "\n"
 
                 text += "**Mixin Target** `" +
-                        "L${clazz.optimumName}" +
+                        "L${clazz.optimumName};" +
                         method.optimumName +
                         mappedDesc +
                         "`"


### PR DESCRIPTION
Fixes:
When getting mappings for a method, the mixin target is missing the semicolon between the class and the method name. For instance, `?ym TickCriterion.trigger` will give the target: 
```
Lnet/minecraft/advancement/criterion/TickCriteriontrigger(Lnet/minecraft/server/network/ServerPlayerEntity;)V
should have a semicolon here ---------------------^
```

This error does not occur for field mixin targets